### PR TITLE
Fix vite build module not found error

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
+    "@vitejs/plugin-react": "^4.2.1",
     "typescript": "5.5.4",
     "vite": "5.4.1"
   }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,8 @@
 import { createRoot } from 'react-dom/client';
 import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
+import '@mantine/core/styles.css';
+import '@mantine/notifications/styles.css';
 import App from './ui/App';
 
 createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
Add missing Vite React plugin and Mantine CSS imports to fix Docker build errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-06f2394f-44a7-47c7-822d-0d90eb304f46">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-06f2394f-44a7-47c7-822d-0d90eb304f46">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

